### PR TITLE
convert tabs to spaces for rb files

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,8 +1,8 @@
 source "https://rubygems.org"
 
 group  :development, :test do
-	gem 'gauge-ruby', '~>0.1.0'
-	gem 'capypage', '~> 0.2.7'
-	gem 'test-unit', '~> 3.0.9'
-	gem 'selenium-webdriver', '~> 2.50.0'
+  gem 'gauge-ruby', '~>0.1.0'
+  gem 'capypage', '~> 0.2.7'
+  gem 'test-unit', '~> 3.0.9'
+  gem 'selenium-webdriver', '~> 2.50.0'
 end

--- a/step_implementations/customer_spec.rb
+++ b/step_implementations/customer_spec.rb
@@ -1,24 +1,24 @@
 require_relative "spec_helper.rb"
 
 step "On the customer page" do
-	GaugeRubyExample::Pages::CustomerPage.visit
+  GaugeRubyExample::Pages::CustomerPage.visit
 end
 
 step "Search for customer <name>" do |name|
-	customer_page.search_user name
+  customer_page.search_user name
 end
 
 step "The customer <name> is listed" do |name|
-	customer_page.verify_user_listed name
+  customer_page.verify_user_listed name
 end
 
 step "Search for customers <table>" do |table|
-	table.rows.each { |row|
-		customer_page.search_user row.first
-		customer_page.verify_user_listed row.first
-	}
+  table.rows.each { |row|
+    customer_page.search_user row.first
+    customer_page.verify_user_listed row.first
+  }
 end
 
 step "Just registered customer is listed" do
-	customer_page.verify_user_listed Gauge::DataStoreFactory.scenario_datastore.get "current_user"
+  customer_page.verify_user_listed Gauge::DataStoreFactory.scenario_datastore.get "current_user"
 end

--- a/step_implementations/pages/base_page.rb
+++ b/step_implementations/pages/base_page.rb
@@ -2,12 +2,12 @@ require 'capypage'
 require 'test/unit'
 
 module GaugeRubyExample
-	module Pages
-		class BasePage < ::Capypage::Page
-			include Test::Unit::Assertions
+  module Pages
+    class BasePage < ::Capypage::Page
+      include Test::Unit::Assertions
 
-			URL = ENV["APP_ENDPOINT"]
-			ADMIN_URL = "#{URL}admin/"
-		end
-	end
+      URL = ENV["APP_ENDPOINT"]
+      ADMIN_URL = "#{URL}admin/"
+    end
+  end
 end

--- a/step_implementations/pages/create_product_page.rb
+++ b/step_implementations/pages/create_product_page.rb
@@ -1,23 +1,23 @@
 module GaugeRubyExample
-	module Pages
-		class CreateProductPage < BasePage
-			set_url "#{ADMIN_URL}products/new"
+  module Pages
+    class CreateProductPage < BasePage
+      set_url "#{ADMIN_URL}products/new"
 
-			element :product_title, '#product_title'
-			element :product_description, '#product_description'
-			element :product_author, '#product_author'
-			element :product_price, '#product_price'
-			element :product_submit, '#main_content fieldset.actions input[name=commit]'
-			element :product_image_file_name, '#product_image_file_name'
+      element :product_title, '#product_title'
+      element :product_description, '#product_description'
+      element :product_author, '#product_author'
+      element :product_price, '#product_price'
+      element :product_submit, '#main_content fieldset.actions input[name=commit]'
+      element :product_image_file_name, '#product_image_file_name'
 
-			def create(title, desc, author, price)
-				product_title.set title
-				product_description.set desc
-				product_author.set author
-				product_price.set price
-				product_image_file_name.set "not available"
-				product_submit.click
-			end
-		end
-	end
+      def create(title, desc, author, price)
+        product_title.set title
+        product_description.set desc
+        product_author.set author
+        product_price.set price
+        product_image_file_name.set "not available"
+        product_submit.click
+      end
+    end
+  end
 end

--- a/step_implementations/pages/customer_page.rb
+++ b/step_implementations/pages/customer_page.rb
@@ -1,20 +1,20 @@
 module GaugeRubyExample
-	module Pages
-		class CustomerPage < BasePage
-			set_url "#{ADMIN_URL}customers/"
+  module Pages
+    class CustomerPage < BasePage
+      set_url "#{ADMIN_URL}customers/"
 
-			element :q_username, "#q_username"
-			element :q_submit, "#new_q input[name=commit]"
-			element :usernameResult, "table#index_table_customers tbody tr:nth-child(1) td.col-username"
+      element :q_username, "#q_username"
+      element :q_submit, "#new_q input[name=commit]"
+      element :usernameResult, "table#index_table_customers tbody tr:nth-child(1) td.col-username"
 
-			def search_user(username)
-				q_username.set username
-				q_submit.click
-			end
+      def search_user(username)
+        q_username.set username
+        q_submit.click
+      end
 
-			def verify_user_listed(username)
-				assert_equal usernameResult.text, username
-			end
-		end
-	end
+      def verify_user_listed(username)
+        assert_equal usernameResult.text, username
+      end
+    end
+  end
 end

--- a/step_implementations/pages/edit_product_page.rb
+++ b/step_implementations/pages/edit_product_page.rb
@@ -1,11 +1,11 @@
 module GaugeRubyExample
-	module Pages
-		class EditProductPage < BasePage
+  module Pages
+    class EditProductPage < BasePage
       set_url "#{ADMIN_URL}products/:product_id/edit"
 
       element :title, "#product_title"
-			element :description, "#product_description"
-			element :author, "#product_author"
+      element :description, "#product_description"
+      element :author, "#product_author"
       element :update_product, "#product_submit_action input[name=commit]"
 
       def set_attribute_value(specifier, value)
@@ -15,6 +15,6 @@ module GaugeRubyExample
       def save
         update_product.click
       end
-		end
-	end
+    end
+  end
 end

--- a/step_implementations/pages/product_list_page.rb
+++ b/step_implementations/pages/product_list_page.rb
@@ -1,20 +1,20 @@
 module GaugeRubyExample
-	module Pages
-		class ProductListPage < BasePage
-			set_url "#{ADMIN_URL}products/"
+  module Pages
+    class ProductListPage < BasePage
+      set_url "#{ADMIN_URL}products/"
 
-			element :q_title, "#q_title"
-			element :q_submit, "input[name='commit']"
-			element :firstProduct, "#main_content table tbody tr:nth-child(1) td.product a"
+      element :q_title, "#q_title"
+      element :q_submit, "input[name='commit']"
+      element :firstProduct, "#main_content table tbody tr:nth-child(1) td.product a"
 
-			def search(name)
-				q_title.set name
-				q_submit.click
-			end
+      def search(name)
+        q_title.set name
+        q_submit.click
+      end
 
-			def open_first_product
-				firstProduct.click
-			end
-		end
-	end
+      def open_first_product
+        firstProduct.click
+      end
+    end
+  end
 end

--- a/step_implementations/pages/product_page.rb
+++ b/step_implementations/pages/product_page.rb
@@ -1,29 +1,29 @@
 module GaugeRubyExample
-	module Pages
-		class ProductPage < BasePage
-			element :id, "#main_content table tbody tr:nth-child(1) td"
-			element :title, "#main_content table tbody tr:nth-child(2) td"
-			element :description, "#main_content table tbody tr:nth-child(3) td"
-			element :author, "#main_content table tbody tr:nth-child(4) td"
-			element :price, "#main_content table tbody tr:nth-child(5) td"
-			element :delete_button, "#titlebar_right div.action_items span.action_item:nth-child(2) a"
+  module Pages
+    class ProductPage < BasePage
+      element :id, "#main_content table tbody tr:nth-child(1) td"
+      element :title, "#main_content table tbody tr:nth-child(2) td"
+      element :description, "#main_content table tbody tr:nth-child(3) td"
+      element :author, "#main_content table tbody tr:nth-child(4) td"
+      element :price, "#main_content table tbody tr:nth-child(5) td"
+      element :delete_button, "#titlebar_right div.action_items span.action_item:nth-child(2) a"
 
-			def verify_author(name)
-				verify_attribute(:author, name)
-			end
+      def verify_author(name)
+        verify_attribute(:author, name)
+      end
 
-			def delete
-				delete_button.click
-				page.driver.browser.switch_to.alert.accept
-			end
+      def delete
+        delete_button.click
+        page.driver.browser.switch_to.alert.accept
+      end
 
-			def verify_attribute(specifier, value)
-				assert_equal send(specifier).text, value
-			end
+      def verify_attribute(specifier, value)
+        assert_equal send(specifier).text, value
+      end
 
-			def save_product_id
-				Gauge::DataStoreFactory.scenario_datastore.put "product_id", id.text
-			end
-		end
-	end
+      def save_product_id
+        Gauge::DataStoreFactory.scenario_datastore.put "product_id", id.text
+      end
+    end
+  end
 end

--- a/step_implementations/pages/sign_up_page.rb
+++ b/step_implementations/pages/sign_up_page.rb
@@ -1,6 +1,6 @@
 module GaugeRubyExample
-	module Pages
-		class SignUpPage < BasePage
+  module Pages
+    class SignUpPage < BasePage
       set_url "#{URL}signup/"
 
       element :username, "#user_username"

--- a/step_implementations/products_spec.rb
+++ b/step_implementations/products_spec.rb
@@ -1,64 +1,64 @@
 require_relative "spec_helper.rb"
 
 step "Create a product <table>" do |table|
-	create_products_page = GaugeRubyExample::Pages::CreateProductPage.new
-	table.rows.each { |row|
-		GaugeRubyExample::Pages::CreateProductPage.visit
-		create_products_page.create row[0], row[1], row[2], row[3]
-	}
+  create_products_page = GaugeRubyExample::Pages::CreateProductPage.new
+  table.rows.each { |row|
+    GaugeRubyExample::Pages::CreateProductPage.visit
+    create_products_page.create row[0], row[1], row[2], row[3]
+  }
 end
 
 step "On product page" do
-	GaugeRubyExample::Pages::ProductListPage.visit
+  GaugeRubyExample::Pages::ProductListPage.visit
 end
 
 step "Search for product <name>" do |name|
-	product_list_page.search name
+  product_list_page.search name
 end
 
 step "Open description for product <name>" do |name|
-	product_list_page.open_first_product
+  product_list_page.open_first_product
 end
 
 # the order of parameters is important, the names do not matter!
 step "Verify product author as <author>" do |author_name|
-	product_page.verify_author author_name
+  product_page.verify_author author_name
 end
 
 step "Delete this product" do
-	product_page.delete
+  product_page.delete
 end
 
 step "On new products page" do
-	GaugeRubyExample::Pages::CreateProductPage.visit
+  GaugeRubyExample::Pages::CreateProductPage.visit
 end
 
 step "Verify product <specifier> as <value>" do |specifier, value|
-	product_page.verify_attribute specifier, value
+  product_page.verify_attribute specifier, value
 end
 
 step "Find and store productId for <title>" do |title|
-	GaugeRubyExample::Pages::ProductListPage.visit
-	product_list_page.search title
-	product_list_page.open_first_product
-	product_page.save_product_id
+  GaugeRubyExample::Pages::ProductListPage.visit
+  product_list_page.search title
+  product_list_page.open_first_product
+  product_page.save_product_id
 end
 
 step "Open product edit page for stored productId" do
-	product_id = Gauge::DataStoreFactory.scenario_datastore.get "product_id"
-	GaugeRubyExample::Pages::EditProductPage.visit :product_id => product_id
+  product_id = Gauge::DataStoreFactory.scenario_datastore.get "product_id"
+  GaugeRubyExample::Pages::EditProductPage.visit :product_id => product_id
 end
 
 step "Update product specifier to new value <table>" do |table|
-	edit_product_page = GaugeRubyExample::Pages::EditProductPage.new
-	table.rows.each do |row|
-		edit_product_page.set_attribute_value row[0], row[1]
-	end
-	edit_product_page.save
+  edit_product_page = GaugeRubyExample::Pages::EditProductPage.new
+  table.rows.each do |row|
+    edit_product_page.set_attribute_value row[0], row[1]
+  end
+  edit_product_page.save
 end
 
 step "Check product specifier has new value <table>" do |table|
-	table.rows.each do |row|
-		product_page.verify_attribute row[0], row[1]
-	end
+  table.rows.each do |row|
+    product_page.verify_attribute row[0], row[1]
+  end
 end

--- a/step_implementations/spec_helper.rb
+++ b/step_implementations/spec_helper.rb
@@ -4,28 +4,28 @@ Dir[File.join(File.dirname(__FILE__), './pages/*.rb')].each {|file| require file
 
 # Define your helpers...
 module GaugeRubyExample
-	module Helpers
-		def customer_page
-			GaugeRubyExample::Pages::CustomerPage.new
-		end
+  module Helpers
+    def customer_page
+      GaugeRubyExample::Pages::CustomerPage.new
+    end
 
-		def product_page
-			GaugeRubyExample::Pages::ProductPage.new
-		end
+    def product_page
+      GaugeRubyExample::Pages::ProductPage.new
+    end
 
-		def product_list_page
-			GaugeRubyExample::Pages::ProductListPage.new
-		end
+    def product_list_page
+      GaugeRubyExample::Pages::ProductListPage.new
+    end
 
-		def sign_up_page
-			GaugeRubyExample::Pages::SignUpPage.new
-		end
-	end
+    def sign_up_page
+      GaugeRubyExample::Pages::SignUpPage.new
+    end
+  end
 end
 
 # Include your helpers!
 Gauge.configure do |config|
-	config.include GaugeRubyExample::Helpers
+  config.include GaugeRubyExample::Helpers
 end
 
 # https://github.com/jnicklas/capybara#drivers


### PR DESCRIPTION
Most ruby community style guides suggest [using spaces over tabs](https://github.com/bbatsov/ruby-style-guide#spaces-indentation).

This PR improves readability and github file view for ruby files by converting tabs to two spaces + saves time for everyone who use this project as a template by cloning it & editing it.
